### PR TITLE
[codex] Zennの記事公開が反映されない問題を修正

### DIFF
--- a/.github/workflows/publish-selected-article.yml
+++ b/.github/workflows/publish-selected-article.yml
@@ -60,7 +60,8 @@ jobs:
           fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m "[skip ci] Publish article: ${ARTICLE_SLUG}"
+          # Zenn Connect uses this push to deploy the article, so do not add [skip ci].
+          git commit -m "Publish article: ${ARTICLE_SLUG}"
           git push origin HEAD:main
 
       - name: Add workflow summary

--- a/articles/build-card-generator-with-codex-from-smartphone.md
+++ b/articles/build-card-generator-with-codex-from-smartphone.md
@@ -36,7 +36,7 @@ CodexでのWebアプリ開発だけでなく、リポジトリを使った家族
 入力内容はリアルタイムでカードへ反映されます。
 完成したカードは高解像度PNGで保存できます。
 
-![Original Card Studioの画面](/images/build-card-generator-with-codex-from-smartphone/app-overview.png)
+![Original Card Studioでポケカ風画像を編集している画面](/images/build-card-generator-with-codex-from-smartphone/app-overview.png)
 
 - 公開URL: [Original Card Studio](https://yuhara-4113-ai.github.io/original-poke-card-generator/)
 - GitHub: [yuhara-4113-ai/original-poke-card-generator](https://github.com/yuhara-4113-ai/original-poke-card-generator)

--- a/qiita/public/build-card-generator-with-codex-from-smartphone.md
+++ b/qiita/public/build-card-generator-with-codex-from-smartphone.md
@@ -1,12 +1,12 @@
 ---
 title: 1年前にCopilotで挫折した「ポケカ風画像生成アプリ」をスマホからCodexへ指示して完成させた
+private: false
 tags:
-  - React
+  - 生成AI
   - 個人開発
   - OpenAI
   - codex
-  - 生成AI
-private: false
+  - React
 updated_at: '2026-07-06T10:44:41+09:00'
 id: 22e34fa082179b5d5700
 organization_url_name: null
@@ -46,7 +46,7 @@ CodexでのWebアプリ開発だけでなく、リポジトリを使った家族
 入力内容はリアルタイムでカードへ反映されます。
 完成したカードは高解像度PNGで保存できます。
 
-![Original Card Studioの画面](https://raw.githubusercontent.com/yuhara-4113-ai/tech-blog/main/images/build-card-generator-with-codex-from-smartphone/app-overview.png)
+![Original Card Studioでポケカ風画像を編集している画面](https://raw.githubusercontent.com/yuhara-4113-ai/tech-blog/main/images/build-card-generator-with-codex-from-smartphone/app-overview.png)
 
 - 公開URL: [Original Card Studio](https://yuhara-4113-ai.github.io/original-poke-card-generator/)
 - GitHub: [yuhara-4113-ai/original-poke-card-generator](https://github.com/yuhara-4113-ai/original-poke-card-generator)


### PR DESCRIPTION
## 変更内容

- 手動公開Workflowが作るコミットから`[skip ci]`を削除
- 今回公開できなかったZenn記事を再同期するため、記事内画像の代替テキストを具体化
- ZennからQiita版を再生成

## 原因

WorkflowはQiitaの公開と`published: true`への更新まで成功していましたが、更新コミットに`[skip ci]`が付いていたため、Zenn Connectによる記事同期が行われませんでした。

GitHub Actionsの`GITHUB_TOKEN`でpushしたコミットから別のWorkflowは再実行されないため、`[skip ci]`を外してもQiita公開が再帰的に動くことはありません。

## 影響

このPRをmainへマージすると対象記事がZennへ再同期されます。今後は「Publish selected article」の実行でQiita公開後にZenn Connectも動作します。

## 確認内容

- `npm run typecheck`
- `npm test`（9件成功）
- `npm run format:check`
- `npx zenn list:articles`
- `git diff --check`
